### PR TITLE
hw/riscv/boot.c: Unify kernel start address

### DIFF
--- a/hw/riscv/boot.c
+++ b/hw/riscv/boot.c
@@ -68,11 +68,7 @@ char *riscv_plic_hart_config_string(int hart_count)
 
 target_ulong riscv_calc_kernel_start_addr(RISCVHartArrayState *harts,
                                           target_ulong firmware_end_addr) {
-    if (riscv_is_32bit(harts)) {
-        return QEMU_ALIGN_UP(firmware_end_addr, 4 * MiB);
-    } else {
-        return QEMU_ALIGN_UP(firmware_end_addr, 2 * MiB);
-    }
+    return QEMU_ALIGN_UP(firmware_end_addr, 4 * MiB);
 }
 
 const char *riscv_default_firmware_name(RISCVHartArrayState *harts)


### PR DESCRIPTION
Current qemu opensbi has different reserved sizes for 32bit and 64bit, caused by different MMU PMD sizes. But, when 64bit uses Sv32, the rule is changed. We can no longer use riscv_is_32bit to distinguish PMD sizes. Here we unify the 4MB reserved size for all PMD sizes, and the side effect is we lost 2MB of Linux system memory. This patch has been tested with opensbi fw_dynamic.bin, but the opensbi fw_jump.bin must be fixed after merging this patch.



Reviewed-by: Weiwei Li <liweiwei@iscas.ac.cn>