### PR TITLE
Reapply "hw/riscv: Change ddr start from 0x80000000 to 0x60000000"

### DIFF
--- a/hw/riscv/virt.c
+++ b/hw/riscv/virt.c
@@ -94,8 +94,8 @@ static const MemMapEntry virt_memmap[] = {
     [VIRT_IMSIC_M] =      { 0x24000000, VIRT_IMSIC_MAX_SIZE },
     [VIRT_IMSIC_S] =      { 0x28000000, VIRT_IMSIC_MAX_SIZE },
     [VIRT_PCIE_ECAM] =    { 0x30000000,    0x10000000 },
-    [VIRT_PCIE_MMIO] =    { 0x40000000,    0x40000000 },
-    [VIRT_DRAM] =         { 0x80000000,           0x0 },
+    [VIRT_PCIE_MMIO] =    { 0x40000000,    0x20000000 },
+    [VIRT_DRAM] =         { 0x60000000,           0x0 },
 };
 
 /* PCIe high mmio is fixed for RV32 */


### PR DESCRIPTION
Only Linux fix it, but not work with RTOS.

See https://github.com/ruyisdk/riscv-gnu-toolchain-rv64ilp32/issues/34

This reverts commit 3c8a0aeee87dfa5cfeb71f53ec85b7551d6f0405.